### PR TITLE
add name check for amd64

### DIFF
--- a/lib/generate_config.ts
+++ b/lib/generate_config.ts
@@ -19,6 +19,9 @@ const getOS = (name: string) => {
 }
 
 const getARCH = (name: string) => {
+  if (/amd64/.test(name)) {
+    return "amd64"
+  }
   if (/x64/i.test(name)) {
     return "amd64"
   }


### PR DESCRIPTION
generatedConfig checks for other variations but doesn't
check for the actual amd64 variant thus discarding packages that
already have the name

Output script changes

gives `linux-amd64` instead of `linux-unknown`

![image](https://user-images.githubusercontent.com/43572006/144703625-94eea6c6-4aff-41f6-a6f1-81e0765e542a.png)
![image](https://user-images.githubusercontent.com/43572006/144703641-c0b89190-21e0-420a-a673-2ab13e7b31e4.png)


