### PR TITLE
docs: add `file` parameter

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -156,7 +156,7 @@ export default function Home() {
                   <code>curl -H "x-github-token:YOUR_TOKEN"</code>
                 </li>
                 <li>
-                  <code>file</code>: Custom file in assert, by default it's the repo name
+                  <code>file</code>: The name of the binary file in the asset, by default it's the same as repo name
                 </li>
               </ul>
             </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -155,6 +155,9 @@ export default function Home() {
                   token via http header:{" "}
                   <code>curl -H "x-github-token:YOUR_TOKEN"</code>
                 </li>
+                <li>
+                  <code>file</code>: Custom file in assert, by default it's the repo name
+                </li>
               </ul>
             </div>
           </Section>


### PR DESCRIPTION
## Goal

Can be used as: `curl -fsSL 'https://bina.egoist.sh/yomorun/cli?file=yomo' | sh` to install binary file `yomo` instead of `cli` by default.

## Problems

for `https://github.com/yomorun/cli`, there is a binary file named `yomo` in the release tar file, by default, bina set this file default name to `cli` which is the repo name.

## Solve

By reading codebase, I find: 

https://github.com/egoist/bina/blob/main/pages/_middleware.ts#L129

the problem can be solved by this `file` parameter.

